### PR TITLE
feat(frontend): refresh after update, redefine Query, unify button color

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -153,7 +153,23 @@
       if(r.ok){ renderList(r,'#projTableWrap',['id','name','description','createdAt'], (row)=>{ $('#projId').value=row.id; $('#projName').value=row.name; $('#projDesc').value=row.description||''; }); toast('已按名称列表，点击下方一行以固定ID'); }
       else { renderOut(r,'#projectsOut'); }
     });
-    $('#projUpdate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#projId').value.trim(); if(!requireUuid(id)) return; const r=await api('/api/projects/'+id,{method:'PUT', body:{name:$('#projName').value, description:$('#projDesc').value}}); renderOut(r,'#projectsOut'); if(r.ok) toast('项目已更新'); });
+    $('#projUpdate').addEventListener('click', async ()=>{
+      if(!requireAuth()) return;
+      const id=$('#projId').value.trim();
+      if(!requireUuid(id)) return;
+      const r = await api('/api/projects/'+id, {
+        method:'PUT',
+        body:{ name: $('#projName').value, description: $('#projDesc').value }
+      });
+      renderOut(r,'#projectsOut');
+      if(r.ok){
+        toast('项目已更新');
+        // 刷新“表示区域”：拉取最新详情，并尝试刷新列表
+        const r2 = await api('/api/projects/'+id);
+        renderOut(r2,'#projectsOut');
+        const btn = $('#projList'); if(btn) btn.click();
+      }
+    });
     $('#projDelete').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#projId').value.trim(); if(!requireUuid(id)) return; const r=await api('/api/projects/'+id,{method:'DELETE'}); renderOut(r,'#projectsOut'); if(r.ok) toast('项目已删除'); });
     $('#projCopyId').addEventListener('click', async ()=>{ const id=$('#projId').value.trim(); if(!isUuid(id)){ toast('尚未选择项目','err'); return; } await navigator.clipboard.writeText(id); toast('已复制项目ID'); });
 
@@ -161,13 +177,44 @@
     $('#taskList').addEventListener('click', async ()=>{ const p=new URLSearchParams({ q:$('#taskQ').value, projectId:$('#taskProjectId').value.trim(), status:$('#taskStatus').value, page:'0', size:'20', sort:'createdAt', order:'desc' }); const r=await api('/api/tasks?'+p.toString()); renderList(r,'#taskTableWrap',['id','projectId','name','status','createdAt'], (row)=>{ $('#taskId').value=row.id; $('#taskName').value=row.name; $('#taskStatus').value=row.status||''; $('#taskProjectId').value=row.projectId||''; }); });
     $('#taskCreate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const r=await api('/api/tasks',{method:'POST', body:{ projectId:$('#taskProjectId').value.trim(), name:$('#taskName').value }}); renderOut(r,'#tasksOut'); if(r.ok) toast('任务已创建'); });
     $('#taskGet').addEventListener('click', async ()=>{ const id=$('#taskId').value.trim(); const r=await api('/api/tasks/'+id); renderOut(r,'#tasksOut'); });
-    $('#taskUpdate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#taskId').value.trim(); if(!requireUuid(id)) return; const r=await api('/api/tasks/'+id,{method:'PUT', body:{ name:$('#taskName').value, status:$('#taskStatus').value||'OPEN'}}); renderOut(r,'#tasksOut'); if(r.ok) toast('任务已更新'); });
+    $('#taskUpdate').addEventListener('click', async ()=>{
+      if(!requireAuth()) return;
+      const id=$('#taskId').value.trim();
+      if(!requireUuid(id)) return;
+      const r = await api('/api/tasks/'+id, {
+        method:'PUT', body:{ name: $('#taskName').value, status: $('#taskStatus').value||'OPEN' }
+      });
+      renderOut(r,'#tasksOut');
+      if(r.ok){
+        toast('任务已更新');
+        const r2 = await api('/api/tasks/'+id);
+        renderOut(r2,'#tasksOut');
+        const btn = $('#taskList'); if(btn) btn.click();
+      }
+    });
     $('#taskDelete').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#taskId').value.trim(); if(!requireUuid(id)) return; const r=await api('/api/tasks/'+id,{method:'DELETE'}); renderOut(r,'#tasksOut'); if(r.ok) toast('任务已删除'); });
 
     // time entries
     $('#teCreate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const body={ taskId:$('#teTaskId').value.trim(), userId:($('#teUserId').value.trim()||userIdFromAccess()), startedAt:($('#teStart').value||isoMinusHours(1)), endedAt:($('#teEnd').value||isoNow()), notes:$('#teNotes').value }; const r=await api('/api/time-entries',{method:'POST', body}); renderOut(r,'#teOut'); if(r.ok) toast('工时已创建'); });
     $('#teGet').addEventListener('click', async ()=>{ const id=$('#teId').value.trim(); const r=await api('/api/time-entries/'+id); renderOut(r,'#teOut'); });
-    $('#teUpdate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#teId').value.trim(); if(!requireUuid(id)) return; const body={ startedAt:($('#teStart').value||isoMinusHours(1)), endedAt:($('#teEnd').value||isoNow()), notes:$('#teNotes').value }; const r=await api('/api/time-entries/'+id,{method:'PUT', body}); renderOut(r,'#teOut'); if(r.ok) toast('工时已更新'); });
+    $('#teUpdate').addEventListener('click', async ()=>{
+      if(!requireAuth()) return;
+      const id=$('#teId').value.trim();
+      if(!requireUuid(id)) return;
+      const body={
+        startedAt: ($('#teStart').value||isoMinusHours(1)),
+        endedAt:   ($('#teEnd').value||isoNow()),
+        notes:     $('#teNotes').value
+      };
+      const r = await api('/api/time-entries/'+id,{method:'PUT', body});
+      renderOut(r,'#teOut');
+      if(r.ok){
+        toast('工时已更新');
+        const r2 = await api('/api/time-entries/'+id);
+        renderOut(r2,'#teOut');
+        const btn = $('#teList'); if(btn) btn.click();
+      }
+    });
     $('#teDelete').addEventListener('click', async ()=>{ if(!requireAuth()) return; const id=$('#teId').value.trim(); if(!requireUuid(id)) return; const r=await api('/api/time-entries/'+id,{method:'DELETE'}); renderOut(r,'#teOut'); if(r.ok) toast('工时已删除'); });
     $('#teList').addEventListener('click', async ()=>{ const p=new URLSearchParams({ start:$('#teFilterStart').value, end:$('#teFilterEnd').value, taskId:$('#teTaskId').value.trim(), userId:$('#teUserId').value.trim(), page:'0', size:'20', sort:'startedAt', order:'desc' }); const r=await api('/api/time-entries?'+p.toString()); renderList(r,'#teTableWrap',['id','taskId','userId','startedAt','endedAt','notes'], (row)=>{ $('#teId').value=row.id; $('#teTaskId').value=row.taskId||''; $('#teUserId').value=row.userId||''; $('#teStart').value=row.startedAt||''; $('#teEnd').value=row.endedAt||''; $('#teNotes').value=row.notes||''; }); });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -143,15 +143,14 @@
     $('#projList').addEventListener('click', async ()=>{ const q = new URLSearchParams({ q: $('#projQ').value, page:'0', size:'20', sort:'createdAt', order:'desc' }); const r = await api('/api/projects?'+q.toString()); renderList(r, '#projTableWrap', ['id','name','description','createdAt'], (row)=>{ $('#projId').value=row.id; $('#projName').value=row.name; $('#projDesc').value=row.description||''; }); });
     $('#projCreate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const r = await api('/api/projects',{method:'POST', body:{ name: $('#projName').value, description: $('#projDesc').value }}); renderOut(r,'#projectsOut'); if(r.ok) toast('项目已创建'); });
     $('#projGet').addEventListener('click', async ()=>{
-      const id=$('#projId').value.trim();
-      if(isUuid(id)){
-        const r=await api('/api/projects/'+id); renderOut(r,'#projectsOut'); return;
-      }
-      // 当未选择具体ID时，退回到按名称列表
-      const q = new URLSearchParams({ q: $('#projQ').value, page:'0', size:'10', sort:'createdAt', order:'desc' });
-      const r = await api('/api/projects?'+q.toString());
-      if(r.ok){ renderList(r,'#projTableWrap',['id','name','description','createdAt'], (row)=>{ $('#projId').value=row.id; $('#projName').value=row.name; $('#projDesc').value=row.description||''; }); toast('已按名称列表，点击下方一行以固定ID'); }
-      else { renderOut(r,'#projectsOut'); }
+      // 查询：不依赖只读的 ID，按其他输入条件检索，并仅刷新“表示区域”
+      const name = ($('#projName').value || $('#projQ').value || '').trim();
+      const p = new URLSearchParams({ q: name, page:'0', size:'20', sort:'createdAt', order:'desc' });
+      const r = await api('/api/projects?'+p.toString());
+      if(!r.ok){ renderOut(r,'#projectsOut'); return; }
+      const arr = Array.isArray(r.data?.content) ? r.data.content : (Array.isArray(r.data)? r.data : (r.data? [r.data]: []));
+      const out = (arr.length===0) ? [] : (arr.length===1 ? arr[0] : arr);
+      renderOut({ok:true,status:200,data:out}, '#projectsOut');
     });
     $('#projUpdate').addEventListener('click', async ()=>{
       if(!requireAuth()) return;
@@ -176,7 +175,16 @@
     // tasks
     $('#taskList').addEventListener('click', async ()=>{ const p=new URLSearchParams({ q:$('#taskQ').value, projectId:$('#taskProjectId').value.trim(), status:$('#taskStatus').value, page:'0', size:'20', sort:'createdAt', order:'desc' }); const r=await api('/api/tasks?'+p.toString()); renderList(r,'#taskTableWrap',['id','projectId','name','status','createdAt'], (row)=>{ $('#taskId').value=row.id; $('#taskName').value=row.name; $('#taskStatus').value=row.status||''; $('#taskProjectId').value=row.projectId||''; }); });
     $('#taskCreate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const r=await api('/api/tasks',{method:'POST', body:{ projectId:$('#taskProjectId').value.trim(), name:$('#taskName').value }}); renderOut(r,'#tasksOut'); if(r.ok) toast('任务已创建'); });
-    $('#taskGet').addEventListener('click', async ()=>{ const id=$('#taskId').value.trim(); const r=await api('/api/tasks/'+id); renderOut(r,'#tasksOut'); });
+    $('#taskGet').addEventListener('click', async ()=>{
+      // 查询：优先使用非 ID 条件（名称、项目ID、状态），返回结果到“表示区域”
+      const name = ($('#taskName').value || $('#taskQ').value || '').trim();
+      const p = new URLSearchParams({ q:name, projectId:$('#taskProjectId').value.trim(), status:$('#taskStatus').value.trim(), page:'0', size:'20', sort:'createdAt', order:'desc' });
+      const r = await api('/api/tasks?'+p.toString());
+      if(!r.ok){ renderOut(r,'#tasksOut'); return; }
+      const arr = Array.isArray(r.data?.content) ? r.data.content : (Array.isArray(r.data)? r.data : (r.data? [r.data]: []));
+      const out = (arr.length===0) ? [] : (arr.length===1 ? arr[0] : arr);
+      renderOut({ok:true,status:200,data:out}, '#tasksOut');
+    });
     $('#taskUpdate').addEventListener('click', async ()=>{
       if(!requireAuth()) return;
       const id=$('#taskId').value.trim();
@@ -196,7 +204,15 @@
 
     // time entries
     $('#teCreate').addEventListener('click', async ()=>{ if(!requireAuth()) return; const body={ taskId:$('#teTaskId').value.trim(), userId:($('#teUserId').value.trim()||userIdFromAccess()), startedAt:($('#teStart').value||isoMinusHours(1)), endedAt:($('#teEnd').value||isoNow()), notes:$('#teNotes').value }; const r=await api('/api/time-entries',{method:'POST', body}); renderOut(r,'#teOut'); if(r.ok) toast('工时已创建'); });
-    $('#teGet').addEventListener('click', async ()=>{ const id=$('#teId').value.trim(); const r=await api('/api/time-entries/'+id); renderOut(r,'#teOut'); });
+    $('#teGet').addEventListener('click', async ()=>{
+      // 查询：使用 taskId/userId/time 窗口等非 ID 条件
+      const p=new URLSearchParams({ start:$('#teFilterStart').value, end:$('#teFilterEnd').value, taskId:$('#teTaskId').value.trim(), userId:$('#teUserId').value.trim(), page:'0', size:'20', sort:'startedAt', order:'desc' });
+      const r = await api('/api/time-entries?'+p.toString());
+      if(!r.ok){ renderOut(r,'#teOut'); return; }
+      const arr = Array.isArray(r.data?.content) ? r.data.content : (Array.isArray(r.data)? r.data : (r.data? [r.data]: []));
+      const out = (arr.length===0) ? [] : (arr.length===1 ? arr[0] : arr);
+      renderOut({ok:true,status:200,data:out}, '#teOut');
+    });
     $('#teUpdate').addEventListener('click', async ()=>{
       if(!requireAuth()) return;
       const id=$('#teId').value.trim();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -69,11 +69,14 @@ input:focus,select:focus,textarea:focus{border-color:#2d3c6f; box-shadow:0 0 0 3
 input[readonly]{opacity:.8; cursor:not-allowed}
 
 button{
-  background:linear-gradient(180deg,#5b85ff,#476ee3); color:#fff; border:none; padding:10px 14px;
+  background:linear-gradient(180deg,#5b85ff,#476ee3); color:#fff; border:1px solid #3f5fd6; padding:10px 14px;
   border-radius:10px; cursor:pointer; transition:transform .04s ease; white-space:nowrap
 }
-button.secondary{background:#142048; color:var(--text); border:1px solid var(--border)}
-button.ghost{background:transparent; border:1px dashed var(--border)}
+/* 统一按钮配色为蓝色 */
+button.secondary,
+button.ghost{
+  background:linear-gradient(180deg,#5b85ff,#476ee3); color:#fff; border:1px solid #3f5fd6;
+}
 button:active{transform:translateY(1px)}
 button:disabled{opacity:.6; cursor:not-allowed}
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,7 +3,9 @@
   "name": "tenantforge-site",
   "builds": [
     { "src": "index.html", "use": "@vercel/static" },
-    { "src": "styles.css", "use": "@vercel/static" }
+    { "src": "styles.css", "use": "@vercel/static" },
+    { "src": "app.js", "use": "@vercel/static" },
+    { "src": "config.js", "use": "@vercel/static" }
   ],
   "routes": [
     { "src": "^/", "dest": "/index.html" }


### PR DESCRIPTION
这次 PR 包含：

1) 更新成功后自动刷新表示区与列表
- 项目/任务/工时：PUT 成功后，立即 GET 详情刷新结果区，并触发一次列表刷新。

2) 重定义“查询”语义（不依赖只读 ID）
- 项目：按名称(q/名称输入框)检索，空结果显示 []。
- 任务：按名称/项目ID/状态检索，空结果显示 []。
- 工时：按任务ID/用户ID/时间窗口检索，空结果显示 []。

3) UI 统一化
- 所有按钮（默认/secondary/ghost）统一为蓝色系；边框色 #3f5fd6。

4) 部署修正
- vercel.json（frontend 子目录）补充 app.js 与 config.js 的静态构建条目，确保文件可直接访问。

后续：合并后由 Vercel Git 集成自动部署到生产；若需要也可保留 GitHub Actions 的 Vercel CLI 部署作为兜底。
